### PR TITLE
initial language patch

### DIFF
--- a/d2hg.pl
+++ b/d2hg.pl
@@ -64,7 +64,7 @@ noun([hero | L],L,Entity, [prop(Entity, type, hero)|C],C).
 noun([support | L],L,Entity, [prop(Entity, role, support)|C],C).
 noun([nuker | L],L,Entity, [prop(Entity, role, nuker)|C],C).
 noun([disabler | L],L,Entity, [prop(Entity, role, disabler)|C],C).
-noun([jungler | L],L,Entity, [prop(Entity, role, jungler)|C],C).
+noun([jungler | L],L,Entity, [prop(Entity, role, jungle)|C],C).
 noun([durable | L],L,Entity, [prop(Entity, role, durable)|C],C).
 noun([escape | L],L,Entity, [prop(Entity, role, escape)|C],C).
 noun([pusher | L],L,Entity, [prop(Entity, role, pusher)|C],C).

--- a/d2hg.pl
+++ b/d2hg.pl
@@ -81,10 +81,10 @@ noun([carry | L],L,Entity, [prop(Entity, role, carry)|C],C).
 %reln([borders | L],L,O1,O2,[borders(O1,O2)|C],C).
 %reln([the,capital,of | L],L,O1,O2, [capital(O2,O1)|C],C).
 %reln([next,to | L],L,O1,O2, [borders(O1,O2)|C],C).
-reln([counters | L],L,prop(O1, type, hero),prop(O2, type, hero), [prop(O1, counters, O2) | C],C).
-reln([counter | L],L,prop(O1, type, hero),prop(O2, type, hero), [prop(O1, counters, O2) | C],C).
-reln([synergizes, with | L],L,prop(O1, type, hero),prop(O2, type, hero), [prop(O1, synergizes, O2) | C],C).
-reln([synergizes| L],L,prop(O1, type, hero),prop(O2, type, hero), [prop(O1, synergizes, O2) | C],C).
+reln([counters | L],L, O1, O2, [prop(O1, counters, O2) | C],C).
+reln([counter | L],L,O1,O2, [prop(O1, counters, O2) | C],C).
+reln([synergizes, with | L],L,O1,O2, [prop(O1, synergizes, O2) | C],C).
+reln([synergizes| L],L,O1,O2, [prop(O1, synergizes, O2) | C],C).
 
 % question(Question,QR,Entity) is true if Query provides an answer about Entity to Question
 question(['Is' | L0],L2,Entity,C0,C2) :-

--- a/d2hg.pl
+++ b/d2hg.pl
@@ -65,6 +65,7 @@ noun([support | L],L,Entity, [prop(Entity, role, support)|C],C).
 noun([nuker | L],L,Entity, [prop(Entity, role, nuker)|C],C).
 noun([disabler | L],L,Entity, [prop(Entity, role, disabler)|C],C).
 noun([jungler | L],L,Entity, [prop(Entity, role, jungle)|C],C).
+noun([jungle | L],L,Entity, [prop(Entity, role, jungle)|C],C).
 noun([durable | L],L,Entity, [prop(Entity, role, durable)|C],C).
 noun([escape | L],L,Entity, [prop(Entity, role, escape)|C],C).
 noun([pusher | L],L,Entity, [prop(Entity, role, pusher)|C],C).

--- a/d2hg.pl
+++ b/d2hg.pl
@@ -1,13 +1,6 @@
-% Prolog representation of a grammar to ask a query of a database
-% Builds a query which can then be asked of the knowledge base
-%  This is not meant to be polished or lingustically reasonable, but purely to show what can be done
+% https://www.swi-prolog.org/FAQ/Multifile.html
+:- multifile prop/3.
 
-% This is expanded code of Figure 13.12 in Section 13.6.6 of
-% Poole and Mackworth, Artificial Intelligence: foundations of
-% computational agents, Cambridge, 2017
-
-% Copyright (c) David Poole and Alan Mackworth 2017. This program
-% is released under GPL, version 3 or later; see http://www.gnu.org/licenses/gpl.html
 
 % noun_phrase(L0,L4,Entity,C0,C4) is true if
 %  L0 and L4 are list of words, such that
@@ -23,8 +16,8 @@ noun_phrase(L0,L4,Entity,C0,C4) :-
     adjectives(L1,L2,Entity,C1,C2),
     noun(L2,L3,Entity,C2,C3),
     mp(L3,L4,Entity,C3,C4).
-noun_phrase(L0,L4,Entity,C0,C4) :-
-    proper_noun(L0,L4,Entity,C0,C4).
+%noun_phrase(L0,L4,Entity,C0,C4) :-
+    %proper_noun(L0,L4,Entity,C0,C4).
 
 % Try:
 %?- noun_phrase([a,spanish,speaking,country],L1,E1,C0,C1).
@@ -38,7 +31,7 @@ det([a | L],L,_,C,C).
 det(L,L,_,C,C).
 
 
-% adjectives(L0,L2,Entity,C0,C2) is true if 
+% adjectives(L0,L2,Entity,C0,C2) is true if
 % L0-L2 is a sequence of adjectives imposes constraints C0-C2 on Entity
 adjectives(L0,L2,Entity,C0,C2) :-
     adj(L0,L1,Entity,C0,C1),
@@ -48,7 +41,7 @@ adjectives(L,L,_,C,C).
 % An optional modifying phrase / relative clause is either
 % a relation (verb or preposition) followed by a noun_phrase or
 % 'that' followed by a relation then a noun_phrase or
-% nothing 
+% nothing
 mp(L0,L2,Subject,C0,C2) :-
     reln(L0,L1,Subject,Object,C0,C1),
     noun_phrase(L1,L2,Object,C1,C2).
@@ -58,23 +51,39 @@ mp([that|L0],L2,Subject,C0,C2) :-
 mp(L,L,_,C,C).
 
 % DICTIONARY
-% adj(L0,L1,Entity,C0,C1) is true if L0-L1 
+% adj(L0,L1,Entity,C0,C1) is true if L0-L1
 % is an adjective that imposes constraints C0-C1 Entity
-adj([large | L],L,Entity, [large(Entity)|C],C).
-adj([Lang,speaking | L],L,Entity, [speaks(Entity,Lang)|C],C).
-adj([Lang,-,speaking | L],L,Entity, [speaks(Entity,Lang)|C],C).
+adj([melee | L],L,Entity, [prop(Entity, attack_type, melee)|C],C).
+adj([ranged | L],L,Entity, [prop(Entity, attack_type, ranged)|C],C).
+adj([strength | L],L,Entity, [prop(Entity, attribute, strength)|C],C).
+adj([agility | L],L,Entity, [prop(Entity, attribute, agility)|C],C).
+adj([intelligence | L],L,Entity, [prop(Entity, attribute, intelligence)|C],C).
 
-noun([country | L],L,Entity, [country(Entity)|C],C).
-noun([city | L],L,Entity, [city(Entity)|C],C).
+
+noun([hero | L],L,Entity, [prop(Entity, type, hero)|C],C).
+noun([support | L],L,Entity, [prop(Entity, role, support)|C],C).
+noun([nuker | L],L,Entity, [prop(Entity, role, nuker)|C],C).
+noun([disabler | L],L,Entity, [prop(Entity, role, disabler)|C],C).
+noun([jungler | L],L,Entity, [prop(Entity, role, jungler)|C],C).
+noun([durable | L],L,Entity, [prop(Entity, role, durable)|C],C).
+noun([escape | L],L,Entity, [prop(Entity, role, escape)|C],C).
+noun([pusher | L],L,Entity, [prop(Entity, role, pusher)|C],C).
+noun([initiator | L],L,Entity, [prop(Entity, role, initiator)|C],C).
+noun([carry | L],L,Entity, [prop(Entity, role, carry)|C],C).
+
 
 % Countries and languages are proper nouns.
 % We could either have it check a language dictionary or add the constraints. We chose to check the dictionary.
-proper_noun([X | L],L,X, C,C) :- country(X).
-proper_noun([X | L],L,X,C,C) :- language(X).
+% proper_noun([X | L],L,X, C,C) :- country(X).
+% proper_noun([X | L],L,X,C,C) :- langauge(X).
 
-reln([borders | L],L,O1,O2,[borders(O1,O2)|C],C).
-reln([the,capital,of | L],L,O1,O2, [capital(O2,O1)|C],C).
-reln([next,to | L],L,O1,O2, [borders(O1,O2)|C],C).
+%reln([borders | L],L,O1,O2,[borders(O1,O2)|C],C).
+%reln([the,capital,of | L],L,O1,O2, [capital(O2,O1)|C],C).
+%reln([next,to | L],L,O1,O2, [borders(O1,O2)|C],C).
+reln([counters | L],L,O1,O2, [prop(O1, counters, O2) | C],C).
+reln([counter | L],L,O1,O2, [prop(O1, counters, O2) | C],C).
+reln([synergizes, with | L],L,O1,O2, [prop(O1, synergizes, O2) | C],C).
+reln([synergizes| L],L,O1,O2, [prop(O1, synergizes, O2) | C],C).
 
 % question(Question,QR,Entity) is true if Query provides an answer about Entity to Question
 question(['Is' | L0],L2,Entity,C0,C2) :-
@@ -87,6 +96,10 @@ question(['What',is | L0],L1,Entity,C0,C1) :-
 question(['What' | L0],L2,Entity,C0,C2) :-
     noun_phrase(L0,L1,Entity,C0,C1),
     mp(L1,L2,Entity,C1,C2).
+question(['Does' | L0],L2,Entity,C0,C2) :-
+    noun_phrase(L0,L1,Entity,C0,C1),
+    mp(L1,L2,Entity,C1,C2).
+
 
 % ask(Q,A) gives answer A to question Q
 ask(Q,A) :-
@@ -107,23 +120,21 @@ prove_all([H|T]) :-
 
 
 %  The Database of Facts to be Queried
-
+/**
 % country(C) is true if C is a country
 country(argentina).
 country(brazil).
 country(chile).
 country(paraguay).
 country(peru).
-country(test_test).
 
 % large(C) is true if the area of C is greater than 2m km^2
 large(brazil).
-large(test_test).
 large(argentina).
 
 % language(L) is true if L is a language
 language(spanish).
-language(portugese).
+langauge(portugese).
 
 % speaks(Country,Lang) is true of Lang is an official language of Country
 speaks(argentina,spanish).
@@ -163,7 +174,7 @@ borders(paraguay,argentina).
 ?- ask(['What',country,borders,chile],A).
 ?- ask(['What',country,that,borders,chile,borders,paraguay],A).
 */
-
+**/
 
 % To get the input from a line:
 
@@ -171,7 +182,7 @@ q(Ans) :-
     write("Ask me: "), flush_output(current_output),
     readln(Ln),
     ask(Ln,Ans).
-   
+
 
 /*
 ?- q(Ans).

--- a/d2hg.pl
+++ b/d2hg.pl
@@ -80,10 +80,10 @@ noun([carry | L],L,Entity, [prop(Entity, role, carry)|C],C).
 %reln([borders | L],L,O1,O2,[borders(O1,O2)|C],C).
 %reln([the,capital,of | L],L,O1,O2, [capital(O2,O1)|C],C).
 %reln([next,to | L],L,O1,O2, [borders(O1,O2)|C],C).
-reln([counters | L],L,O1,O2, [prop(O1, counters, O2) | C],C).
-reln([counter | L],L,O1,O2, [prop(O1, counters, O2) | C],C).
-reln([synergizes, with | L],L,O1,O2, [prop(O1, synergizes, O2) | C],C).
-reln([synergizes| L],L,O1,O2, [prop(O1, synergizes, O2) | C],C).
+reln([counters | L],L,prop(O1, type, hero),prop(O2, type, hero), [prop(O1, counters, O2) | C],C).
+reln([counter | L],L,prop(O1, type, hero),prop(O2, type, hero), [prop(O1, counters, O2) | C],C).
+reln([synergizes, with | L],L,prop(O1, type, hero),prop(O2, type, hero), [prop(O1, synergizes, O2) | C],C).
+reln([synergizes| L],L,prop(O1, type, hero),prop(O2, type, hero), [prop(O1, synergizes, O2) | C],C).
 
 % question(Question,QR,Entity) is true if Query provides an answer about Entity to Question
 question(['Is' | L0],L2,Entity,C0,C2) :-


### PR DESCRIPTION
Works for statements like "what is an intelligence hero" and "what is a ranged intelligence nuker," but not for "what is a hero that counters abaddon." Think it's an issue with the reln statements.